### PR TITLE
#9 RepreZen import should work with *.rapid files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ gradle-app.setting
 
 # Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
 !gradle-wrapper.jar
+/target/

--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
 	</build>
 
 	<properties>
-		<reprezen.version>0.8.207.881</reprezen.version>
+		<reprezen.version>1.2.0.1011</reprezen.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 

--- a/src/main/groovy/com/modelsolv/reprezen/soapui/RepreZenExporter.groovy
+++ b/src/main/groovy/com/modelsolv/reprezen/soapui/RepreZenExporter.groovy
@@ -269,7 +269,7 @@ class RepreZenExporter {
 	}
 
 	public static String createFileName( String path, String title ) {
-		return path + File.separatorChar + StringUtils.createFileName( title, (char)'-' ) + ".zen"
+		return path + File.separatorChar + StringUtils.createFileName( title, (char)'-' ) + ".rapid"
 	}
 
 	static boolean hasContent( String str ) {

--- a/src/test/groovy/com/modelsolv/reprezen/soapui/exporter/ExportModelsCreatedByImporterTests.groovy
+++ b/src/test/groovy/com/modelsolv/reprezen/soapui/exporter/ExportModelsCreatedByImporterTests.groovy
@@ -9,13 +9,13 @@ import com.modelsolv.reprezen.soapui.importer.RepreZenImporterTest
 class ExportModelsCreatedByImporterTests extends GroovyTestCase {
 
 	public void testTaxBlaster() {
-		String modelText = exportImportedModel("TaxBlaster.zen")
+		String modelText = exportImportedModel("TaxBlaster.rapid")
 		Console.println( modelText )
 		RepreZenExporterTests.validateModel(modelText)
 	}
 
 	public void testTaxBlasterWithExamples() {
-		String modelText = exportImportedModel("TaxBlasterWithExamples.zen")
+		String modelText = exportImportedModel("TaxBlasterWithExamples.rapid")
 		Console.println( modelText )
 		RepreZenExporterTests.validateModel(modelText)
 	}

--- a/src/test/groovy/com/modelsolv/reprezen/soapui/exporter/RepreZenExporterTests.groovy
+++ b/src/test/groovy/com/modelsolv/reprezen/soapui/exporter/RepreZenExporterTests.groovy
@@ -66,7 +66,7 @@ class RepreZenExporterTests extends GroovyTestCase {
 
 	public static void validateModel(String modelText) {
 		new XtextDslStandaloneSetup().createInjectorAndDoEMFRegistration();
-		XtextResource resource = new XtextResourceSet().createResource(URI.createURI("resource.zen"));
+		XtextResource resource = new XtextResourceSet().createResource(URI.createURI("resource.rapid"));
 		resource.load(new URIConverter.ReadableInputStream(modelText, "UTF-8"), null);
 		for (Resource.Diagnostic error: resource.validateConcreteSyntax()) {
 			fail(error.getMessage());

--- a/src/test/groovy/com/modelsolv/reprezen/soapui/importer/ExamplesTest.groovy
+++ b/src/test/groovy/com/modelsolv/reprezen/soapui/importer/ExamplesTest.groovy
@@ -21,7 +21,7 @@ class ExamplesTest extends GroovyTestCase {
 """
 
 	public void testInlineExamples() {
-		RestService restService = RepreZenImporterTest.importRepreZen("TaxBlasterWithExamples.zen")
+		RestService restService = RepreZenImporterTest.importRepreZen("TaxBlasterWithExamples.rapid")
 		def Map<String, RestResource> resources = restService.getResources()
 		assert resources.size() == 5
 		RestResource objectResource = resources.get("/people")
@@ -62,7 +62,7 @@ class ExamplesTest extends GroovyTestCase {
 	}
 
 	public void testExternalExamplesInResponse() {
-		RestService restService = RepreZenImporterTest.importRepreZen("externalExamples/TaxBlasterWithExternalExamples.zen")
+		RestService restService = RepreZenImporterTest.importRepreZen("externalExamples/TaxBlasterWithExternalExamples.rapid")
 		def Map<String, RestResource> resources = restService.getResources()
 		assert resources.size() == 2
 		RestResource objectResource = resources.get("/people/{id}")
@@ -79,7 +79,7 @@ class ExamplesTest extends GroovyTestCase {
 	}
 
 	public void testExternalExamplesInRequest() {
-		RestService restService = RepreZenImporterTest.importRepreZen("externalExamples/TaxBlasterWithExternalExamples.zen")
+		RestService restService = RepreZenImporterTest.importRepreZen("externalExamples/TaxBlasterWithExternalExamples.rapid")
 		def Map<String, RestResource> resources = restService.getResources()
 		assert resources.size() == 2
 		RestResource objectResource = resources.get("/people/{id}")

--- a/src/test/groovy/com/modelsolv/reprezen/soapui/importer/ImportedDataModelTest.groovy
+++ b/src/test/groovy/com/modelsolv/reprezen/soapui/importer/ImportedDataModelTest.groovy
@@ -13,7 +13,7 @@ import com.modelsolv.reprezen.restapi.HTTPMethods;
 class ImportedDataModelTest extends GroovyTestCase {
 
 	public void testDataModelImport() {
-		RestService restService = RepreZenImporterTest.importRepreZen("dataModelImport/TaxBlaster.zen")
+		RestService restService = RepreZenImporterTest.importRepreZen("dataModelImport/TaxBlaster.rapid")
 		def Map<String, RestResource> resources = restService.getResources()
 		assert resources.size() == 4
 	}

--- a/src/test/groovy/com/modelsolv/reprezen/soapui/importer/RepreZenImporterTest.groovy
+++ b/src/test/groovy/com/modelsolv/reprezen/soapui/importer/RepreZenImporterTest.groovy
@@ -17,7 +17,7 @@ class RepreZenImporterTest extends GroovyTestCase {
 	RestService restService;
 
 	protected void setUp() {
-		restService = importRepreZen("TaxBlaster.zen")
+		restService = importRepreZen("TaxBlaster.rapid")
 	}
 	protected void tearDown() {
 		restService = null

--- a/src/test/resources/TaxBlaster.rapid
+++ b/src/test/resources/TaxBlaster.rapid
@@ -1,7 +1,7 @@
 /* 
   This is the TaxBlaster API model created in the RepreZen Quick Start guide.
 */
-zenModel TaxBlaster
+rapidModel TaxBlaster
 	resourceAPI TaxBlasterInterface baseURI "http://taxblaster.com/api"
 
 		/** The Index Resource is the entry point to the TaxBlaster API. To minimize 

--- a/src/test/resources/TaxBlasterWithExamples.rapid
+++ b/src/test/resources/TaxBlasterWithExamples.rapid
@@ -1,7 +1,7 @@
 /* 
   The TaxBlaster model contains the REST interface for TaxBlaster, and its supporting datatypes.
 */
-zenModel TaxBlasterWithExamples
+rapidModel TaxBlasterWithExamples
 	resourceAPI TaxBlasterInterface baseURI "http://taxblaster.com/api"
 		/** The Index Resource is the entry point to the TaxBlaster API.  
     To minimize coupling, consuming applications should start here, 

--- a/src/test/resources/dataModelImport/TaxBlaster.rapid
+++ b/src/test/resources/dataModelImport/TaxBlaster.rapid
@@ -1,6 +1,6 @@
-import TaxBlaster.DataModel from "TaxBlasterDataModel.zen" 
+import TaxBlaster.DataModel from "TaxBlasterDataModel.rapid" 
 
-zenModel TaxBlaster
+rapidModel TaxBlaster
 
 	resourceAPI InterfaceModel baseURI "http://localhost:8080"
 	

--- a/src/test/resources/dataModelImport/TaxBlasterDataModel.rapid
+++ b/src/test/resources/dataModelImport/TaxBlasterDataModel.rapid
@@ -1,4 +1,4 @@
-zenModel TaxBlaster
+rapidModel TaxBlaster
 
 	dataModel DataModel
 	

--- a/src/test/resources/externalExamples/TaxBlasterWithExternalExamples.rapid
+++ b/src/test/resources/externalExamples/TaxBlasterWithExternalExamples.rapid
@@ -25,7 +25,7 @@
   
   Green comments are used in the code to draw attention to the feature being demonstrated in this example.
 */
-zenModel TaxBlaster
+rapidModel TaxBlaster
 	resourceAPI TaxBlasterInterface baseURI "http://taxblaster.com/api"
 
 		objectResource TaxFilingObject type TaxFiling


### PR DESCRIPTION
RepreZen API Studio changes file extension and a keyword for `rapidModel` recently. I upgraded dependency to RepreZen deserializer, updated the default extension for model exported from Ready! API to RepreZen and fixed the tests.

@tedepstein , can you please review?
